### PR TITLE
Setup travis-ci for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 app
 bower_components
+**/.bundle/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: ruby
+
+rvm:
+  - 2.0.0
+
+gemfile: travis/Gemfile
+
+before_script:
+  - sh -e /etc/init.d/xvfb start
+
+script: DISPLAY=:99.0 bundle exec rake jasmine:ci -f travis/Rakefile
+
+env:
+  global:
+    - JASMINE_BROWSER=firefox
+    - BUNDLE_GEMFILE=travis/Gemfile
+    - JASMINE_CONFIG_PATH=travis/jasmine.yml

--- a/travis/Gemfile
+++ b/travis/Gemfile
@@ -1,0 +1,7 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+group :development, :test do
+  gem 'jasmine'
+  gem 'jasmine_selenium_runner'
+end

--- a/travis/Rakefile
+++ b/travis/Rakefile
@@ -1,0 +1,4 @@
+require 'jasmine'
+require 'jasmine_selenium_runner'
+require 'jasmine'
+load 'jasmine/tasks/jasmine.rake'

--- a/travis/jasmine.yml
+++ b/travis/jasmine.yml
@@ -1,0 +1,64 @@
+src_files:
+  - '**/*.js'
+
+spec_files:
+  - '**/*.js'
+
+src_dir: 'src'
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir: 'tests'
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+


### PR DESCRIPTION
a couple of notes about this:
- unfortunately because of the nature of this project and PhantomJS's
  lack of support for the web audio api, tests must be run in a real
  browser
- I looked extensively for a solution that will work with PhantomJS i.e.
  a web audio api mocking library but no luck
- additionally, there don't seem to be any grunt compatible libraries
  that _do not_ use phantomjs and support Jasmine 2.0
- see
  https://github.com/RallySoftware/grunt-webdriver-jasmine-runner/issues/8
  for a library that supports webdriver/selenium but not jasmine 2.0
- the implemented solution works well for the moment and namespaces
  everything in the travis directory and although it's in ruby, it should never be needed to be installed in a normal dev workflow. I tried every node based option I could find.
- will be opening an additional ticket for the fact that tests do not
  pass in firefox
