### PR TITLE
Add support for note names in oscillator function

### DIFF
--- a/src/tsw-core.js
+++ b/src/tsw-core.js
@@ -10,6 +10,7 @@
 'use strict';
 
 var helpers = require('./helpers');
+var tswMusic = require('./tsw-music');
 
 var tsw,
     version = '0.11.2';
@@ -845,7 +846,7 @@ tsw = (function () {
      * @param {string} waveType The type of wave form.
      * @return {node} Oscillator node of specified type.
      */
-    tsw.oscillator = function (frequency, waveType) {
+    tsw.oscillator = function (frequencyOrNote, waveType) {
         var node,
             osc = tsw.context().createOscillator();
 
@@ -863,7 +864,12 @@ tsw = (function () {
             detune: osc.detune
         };
 
-        node.frequency(frequency || 440);
+        if (helpers.isString(frequencyOrNote)) {
+            node.frequency(tswMusic.frequency(frequencyOrNote));
+        } else {
+            node.frequency(frequencyOrNote || 440);
+        }
+
         node.type((waveType || 'sine').toLowerCase());
 
         node.isPlaying = function () {

--- a/tests/tsw-core-tests.js
+++ b/tests/tsw-core-tests.js
@@ -255,6 +255,11 @@ describe('Core', function () {
             osc.frequency(900);
             expect(osc.frequency()).to.eq(900);
         });
+
+        it('Creates an oscillator with a note name', function () {
+            var osc = tsw.osc('D#3', 'sawtooth');
+            expect(osc.frequency()).to.eq(155.56349186104046);
+        });
     });
 
     describe('Create Gain', function () {


### PR DESCRIPTION
Fixes #26

Modify the `tsw.oscillator` function to accept note names or frequencies.

* **Core Functionality**
  - Import `tsw-music` module in `src/tsw-core.js`.
  - Modify `tsw.oscillator` function to accept `frequencyOrNote` parameter.
  - Add logic to check if `frequencyOrNote` is a string (note name) and convert it to frequency using `tswMusic.frequency`.
  - Set oscillator frequency based on the converted frequency or the provided frequency.

* **Testing**
  - Add a test in `tests/tsw-core-tests.js` to verify that the `tsw.oscillator` function works with note names.
  - Ensure the test checks the frequency of the oscillator when a note name is passed.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/stuartmemo/theresas-sound-world/pull/124?shareId=10ea8345-08cf-4bea-bec6-df078f254ce7).